### PR TITLE
Added a sentence on BLE to the intro in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Learning is more meaningful and relatable when experimenting with and simulating
 
 We offer both synchronous and asynchronous Python programming libraries for the intelino smart train. The `intelino-trainlib` is our synchronous Python library. It gives access to our full-featured API, enables event-based programming (through threads) and allows to interactively control one or multiple smart trains. This library is well suited for students and users that are new to Python or text-based programming, in general. And programmers with more advanced skills may prefer our asynchronous library `intelino-trainlib-async` which offers an extended list of API features, Rx-based reactive programming and superior performance.
 
+The code executes in a python interpreter running on your computer - which connects to the train via bluetooth low energy.
+
 ## Installation
 
 The intelino trainlib is available on PyPi and can be installed with pip:


### PR DESCRIPTION
This is kind of a dummy PR - you can reword what I've written and discard this PR. But this was the information I was missing when I first pulled up the code - it wasn't clear to me whether the train engine was running an embedded linux kernel and so python interpreter, or whether the interpreter was running on my computer, until I dug a little into the docs. The info on BLE all looks to be there in the docs - great - but it would be useful just to surface it right here from the get go. Love the concept :)